### PR TITLE
ci: cancel redundant check-release runs

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zizmor:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds workflow-level concurrency to `.github/workflows/check-release.yml` so only the newest run per branch/PR stays active.

## Why
This is a high-impact, low-effort performance win for CI throughput:
- prevents duplicate runs from consuming runners on force-pushes/rebases
- shortens feedback latency by prioritizing the latest commit
- reduces compute waste without changing release validation behavior

## Change
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

## Risk
Low: only run scheduling changes; job logic remains unchanged.

## Summary by Sourcery

CI:
- Configure concurrency for the check-release workflow to cancel in-progress runs when newer runs on the same branch or pull request are triggered.